### PR TITLE
Updated to use projection

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -20,6 +20,9 @@ PROJECT=CONFIGURE_ME
 # The project in which to scan for buckets / objects only. Use this (or BIGQUERY.JOB_PROJECT) if to span BQ and GCS across different projects.
 # GCS_PROJECT=CONFIGURE_ME
 
+# Inventories object ACLS for objects in buckets without uniform bucket-level access (UBLA) enabled. NOTE: This option can add considerable time to the scan. 
+# ACLS=yes
+
 [RUNTIME]
 # Number of worker threads. Two threads will be reserved for listing buckets, and the remaining threads will be used to send list pages into BigQuery. Even on a single core machine, this should be set to at least 4 to allow for context switches during IO waits.
 WORKERS=64

--- a/gcs_inventory_loader/bq/tables.py
+++ b/gcs_inventory_loader/bq/tables.py
@@ -118,7 +118,7 @@ class TableDefinitions(Enum):
     INVENTORY = {
         "schema":
         """
-                acl ARRAY<STRUCT<role STRING, entity STRING>>,
+                acl ARRAY<STRUCT<kind STRING, object STRING, generation INT64, id STRING, selfLink STRING, bucket STRING, entity STRING, role STRING, email STRING, etag STRING, projectTeam STRUCT<projectNumber STRING, team STRING>>>,
                 bucket STRING,
                 cacheControl STRING,
                 componentCount INT64,
@@ -152,7 +152,6 @@ class TableDefinitions(Enum):
                 updated TIMESTAMP
             """  # noqa: E501
     }
-
 
 def get_table(table: TableDefinitions, name: str = None) -> Table:
     """    Get a Table object using one of the TableDefinitions enum

--- a/gcs_inventory_loader/cli/cat.py
+++ b/gcs_inventory_loader/cli/cat.py
@@ -109,6 +109,9 @@ def page_outputter(config: ConfigParser, bucket: Bucket, page: Page,
         stats {dict} -- A dictionary of bucket_name (str): blob_count (int)
     """
     blob_count = 0
+
+    get_acl=config.getboolean("GCP","ACLS",fallback=False)
+
     for blob in page:
         blob_count += 1
         # pylint: disable=protected-access
@@ -118,7 +121,8 @@ def page_outputter(config: ConfigParser, bucket: Bucket, page: Page,
                 "key": k,
                 "value": v
             } for k, v in blob_metadata["metadata"].items()]
-        # blob_metadata["acl"] = list(blob.acl)  # TODO: this breaks on UBLA
+        if get_acl is True and bucket.iam_configuration.bucket_policy_only_enabled is False:
+            blob_metadata["acl"] = list(blob.acl)
         print(blob_metadata)
 
     if blob_count:

--- a/gcs_inventory_loader/cli/cat.py
+++ b/gcs_inventory_loader/cli/cat.py
@@ -87,12 +87,21 @@ def bucket_lister(config: ConfigParser, gcs: Client, bucket: Bucket,
              total_buckets)
     stats[bucket] = 0
 
+    # Check config to determine whether to retrieve ACL for each blob
+    get_acl=config.getboolean("GCP","ACLS",fallback=False)
+    projection=''
+
+    if get_acl is True:
+        projection = 'full'
+    else:
+        projection = 'noAcl'
+
     # Use remaining configured workers, or at least 2, for this part
     workers = max(config.getint('RUNTIME', 'WORKERS') - 2, 2)
     size = int(config.getint('RUNTIME', 'WORK_QUEUE_SIZE') * .75)
     with BoundedThreadPoolExecutor(max_workers=workers,
                                    queue_size=size) as sub_executor:
-        blobs = gcs.list_blobs(bucket, prefix=prefix)
+        blobs = gcs.list_blobs(bucket, prefix=prefix, projection=projection)
         for page in blobs.pages:
             sub_executor.submit(page_outputter, config, bucket, page, stats)
             sleep(0.02)  # small offset to avoid thundering herd
@@ -121,8 +130,6 @@ def page_outputter(config: ConfigParser, bucket: Bucket, page: Page,
                 "key": k,
                 "value": v
             } for k, v in blob_metadata["metadata"].items()]
-        if get_acl is True and bucket.iam_configuration.bucket_policy_only_enabled is False:
-            blob_metadata["acl"] = list(blob.acl)
         print(blob_metadata)
 
     if blob_count:

--- a/gcs_inventory_loader/cli/load.py
+++ b/gcs_inventory_loader/cli/load.py
@@ -120,6 +120,8 @@ def page_outputter(config: ConfigParser, bucket: Bucket, page: Page,
                   config.get("BIGQUERY", "INVENTORY_TABLE")), False)
     blob_count = 0
 
+    get_acl=config.getboolean("GCP","ACLS",fallback=False)
+
     for blob in page:
         blob_count += 1
         # pylint: disable=protected-access
@@ -129,7 +131,8 @@ def page_outputter(config: ConfigParser, bucket: Bucket, page: Page,
                 "key": k,
                 "value": v
             } for k, v in blob_metadata["metadata"].items()]
-        # blob_metadata["acl"] = list(blob.acl)  # TODO: this breaks on UBLA
+        if get_acl is True and bucket.iam_configuration.bucket_policy_only_enabled is False:
+            blob_metadata["acl"] = list(blob.acl)
         LOG.debug("Outputting blob record {}".format(blob_metadata))
         output.put(blob_metadata)
 

--- a/gcs_inventory_loader/cli/load.py
+++ b/gcs_inventory_loader/cli/load.py
@@ -94,12 +94,21 @@ def bucket_lister(config: ConfigParser, gcs: Client, bucket: Bucket,
              total_buckets)
     stats[bucket] = 0
 
+    # Check config to determine whether to retrieve ACL for each blob
+    get_acl=config.getboolean("GCP","ACLS",fallback=False)
+    projection=''
+
+    if get_acl is True:
+        projection = 'full'
+    else:
+        projection = 'noAcl'
+
     # Use remaining configured workers, or at least 2, for this part
     workers = max(config.getint('RUNTIME', 'WORKERS') - 2, 2)
     size = int(config.getint('RUNTIME', 'WORK_QUEUE_SIZE') * .75)
     with BoundedThreadPoolExecutor(max_workers=workers,
                                    queue_size=size) as sub_executor:
-        blobs = gcs.list_blobs(bucket, prefix=prefix)
+        blobs = gcs.list_blobs(bucket, prefix=prefix, projection=projection)
         for page in blobs.pages:
             sub_executor.submit(page_outputter, config, bucket, page, stats)
             sleep(0.02)  # small offset to avoid thundering herd
@@ -131,8 +140,6 @@ def page_outputter(config: ConfigParser, bucket: Bucket, page: Page,
                 "key": k,
                 "value": v
             } for k, v in blob_metadata["metadata"].items()]
-        if get_acl is True and bucket.iam_configuration.bucket_policy_only_enabled is False:
-            blob_metadata["acl"] = list(blob.acl)
         LOG.debug("Outputting blob record {}".format(blob_metadata))
         output.put(blob_metadata)
 


### PR DESCRIPTION
I saw you had to revert my contribution because accessing the property errored on objects in buckets where UBLA is enabled. Sorry I didn't catch that in testing. For what I was doing it didn't matter so all my testing numbers checked out. 

In this pull request I made your suggested update to use full projection in the initial call and it is so much faster (I didn't see a noticeable difference between full projection and noAcl projection) and I am not seeing errors on buckets with UBLA enabled. Even though it doesn't seem to matter, I think you are right to be cautious about always using full projection so I added a field to the config to make ACL retrieval optional. 