### PR TITLE
Check if config file exists before reading

### DIFF
--- a/gcs_inventory_loader/config.py
+++ b/gcs_inventory_loader/config.py
@@ -18,6 +18,7 @@ arguments and config files.
 
 import io
 from configparser import ConfigParser
+from pathlib import Path
 
 
 class ConfigParserHolder():
@@ -40,7 +41,13 @@ def set_config(config_file: str) -> ConfigParser:
 
     Returns:
         ConfigParser -- The stored parsed configuration.
+
+    Raises:
+        FileNotFoundError -- If the config file does not exist.
     """
+    if not Path(config_file).is_file():
+        raise FileNotFoundError("Configuration file '{}' was not found.".
+                                format(config_file))
 
     config = ConfigParser()
     config.read(config_file)


### PR DESCRIPTION
Raise `FileNotFoundError` if file not found

I moved my config files but later on forgot to update my command with the new path. This didn't cause an error when trying to read the config file. Instead, the error was `configparser.NoSectionError: No section: 'GCP'` when it tried to access a value within the empty, supposedly read config.

This was unhelpful in finding my mistake, so I've added a `FileNotFoundError` to the `set_config(config_file)` function.